### PR TITLE
Fix: redirect invalid HTTP codes to 500

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,12 @@ app.get('/api', (req, res, next) => {
 
 // Read parameter and set to statusId
 app.param('id', function (req, res, next, id) {
-  statusId = parseInt(id)
+  // Prevent invalid codes
+  if(typeof allStatus[id] === 'undefined') {
+     statusId = 500
+  } else {
+    statusId = parseInt(id)
+  }
   next()
 })
 

--- a/test/index.js
+++ b/test/index.js
@@ -49,7 +49,7 @@ describe('main App', function(){
         })
     })
 
-        describe('get /api/400', function(){
+    describe('get /api/400', function(){
         it('Should NOT return image uri', function(done){
             request(app)
                 .get('/api/400')
@@ -58,6 +58,21 @@ describe('main App', function(){
                 .expect(400)
                 .then(res => {
                     expect(res.body, 'It seems to be NOT Ok').to.not.match(/image/)
+                    done()
+                })
+                .catch(err => done(err))
+        })
+    })
+
+    describe('get /api/Invalid', function(){
+        it('Should Return 500', function(done){
+            request(app)
+                .get('/api/Invalid')
+                .set('Accept','application/json')
+                .expect('Content-Type', /json/)
+                .expect(500)
+                .then(res => {
+                    expect(res.body.code, 500)
                     done()
                 })
                 .catch(err => done(err))


### PR DESCRIPTION
If user sends /api/Invalid (or any non exists HTTP Code) redirects to /api/500 